### PR TITLE
Feature: revalidate form on change after first submit

### DIFF
--- a/src/hoc/connectForm.actions.js
+++ b/src/hoc/connectForm.actions.js
@@ -1,4 +1,4 @@
 const UPDATE_FORM = '@urf/action/updateForm';
+const REQUEST_SUBMIT = '@urf/action/requestSubmit';
 
-// eslint-disable-next-line import/prefer-default-export
-export { UPDATE_FORM };
+export { UPDATE_FORM, REQUEST_SUBMIT };

--- a/src/hoc/connectForm.js
+++ b/src/hoc/connectForm.js
@@ -47,6 +47,7 @@ const connectForm = options => Target => {
       values: { ...defaultValues, ...initialValues },
       errors: null,
       touched: false,
+      submitCount: 0,
       validationCount: 0,
     });
 
@@ -72,7 +73,7 @@ const connectForm = options => Target => {
         return true;
       }
 
-      return eventType === validationMode;
+      return eventType === validationMode || (eventType === Events.ON_CHANGE && state.submitCount > 0);
     };
 
     const runValidation = async () => {
@@ -96,6 +97,7 @@ const connectForm = options => Target => {
     const emitEvent = async ({ type, name, value }) => {
       switch (type) {
         case Events.ON_SUBMIT:
+          await dispatch({ type: Actions.REQUEST_SUBMIT });
           await validateIfNeeded(type);
 
           if (onSubmit && !newErrors) {

--- a/src/hoc/connectForm.reducer.js
+++ b/src/hoc/connectForm.reducer.js
@@ -5,6 +5,8 @@ const urfReducer = (state, action) => {
   switch (action.type) {
     case Actions.UPDATE_FORM:
       return { ...state, ...action.payload };
+    case Actions.REQUEST_SUBMIT:
+      return { ...state, submitCount: state.submitCount + 1 };
     default:
       return state;
   }

--- a/tests/urfReducer-test.js
+++ b/tests/urfReducer-test.js
@@ -19,4 +19,12 @@ describe('URF Reducer', () => {
     expect(Object.hasOwnProperty.call(state.values, 'name')).toBe(true);
     expect(state.values.name).toBe('Jim');
   });
+
+  it('should increment the submit count', () => {
+    const handleAction = { type: Actions.REQUEST_SUBMIT };
+    const state = urfReducer({ values: null, submitCount: 0 }, handleAction);
+
+    expect(state.values === null).toBe(true);
+    expect(state.submitCount).toBe(1);
+  });
 });


### PR DESCRIPTION
It allows validation to run automatically on change after the first submit occurred and validation mode is set to `onSubmit`.

This will provide a real-time feedback to the user compiling the form while trying to fix the errors occurred during the first submit attempt.